### PR TITLE
Fix: Correct subdirectory path in uvx Git source to avoid resolve error

### DIFF
--- a/server/mcp_server_vefaas_function/README.md
+++ b/server/mcp_server_vefaas_function/README.md
@@ -625,7 +625,7 @@ OAuth 2.0
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/volcengine/mcp-server#subdirectory=/server/mcp_server_vefaas_function",
+        "git+https://github.com/volcengine/mcp-server#subdirectory=server/mcp_server_vefaas_function",
         "mcp-server-vefaas-function"
       ],
       "env": {


### PR DESCRIPTION
This PR fixes an invalid subdirectory path used in the uvx Git source.
Previously, the path was incorrectly prefixed with a slash (/server/mcp_server_vefaas_function), causing uvx to fail with:

```
Failed to resolve --with requirement
The source distribution ... has no subdirectory `/server/...`
```

The corrected path (server/mcp_server_vefaas_function) now allows uvx to locate the module and proceed as expected.

