### PR TITLE
fix: 修复live readme中有不合理字段

### DIFF
--- a/server/mcp_server_live/README.md
+++ b/server/mcp_server_live/README.md
@@ -116,7 +116,7 @@ use uvx to directly run mcp-server-live.
 ```json
 {
     "mcpServers": {
-      "mcp-server": {
+      "mcp-live": {
         "command": "uv",
         "args": [
           "--directory",
@@ -140,7 +140,7 @@ OR
 ```json
 {
   "mcpServers": {
-    "mcp-server": {
+    "mcp-live": {
       "command": "uv",
       "args": [
         "--directory",
@@ -164,7 +164,7 @@ OR
 ```json
 {
   "mcp-server": {
-    "tos-mcp": {
+    "mcp-live": {
       "command": "uvx",
       "args": [
         "--from",

--- a/server/mcp_server_live/README_zh.md
+++ b/server/mcp_server_live/README_zh.md
@@ -110,7 +110,7 @@ v1
 ```json
 {
     "mcpServers": {
-      "mcp-server": {
+      "mcp-live": {
         "command": "uv",
         "args": [
           "--directory",
@@ -134,7 +134,7 @@ OR
 ```json
 {
   "mcpServers": {
-    "mcp-server": {
+    "mcp-live": {
       "command": "uv",
       "args": [
         "--directory",
@@ -158,7 +158,7 @@ OR
 ```json
 {
   "mcp-server": {
-    "tos-mcp": {
+    "mcp-live": {
       "command": "uvx",
       "args": [
         "--from",


### PR DESCRIPTION
去掉readme中的tos