### PR TITLE
refactor(env-vars): Update environment variable names for consistency

### DIFF
--- a/server/mcp_server_vefaas_function/README.md
+++ b/server/mcp_server_vefaas_function/README.md
@@ -601,7 +601,7 @@ OAuth 2.0
 
 ### UVX
 
-请预先获取环境变量 VOLC_ACCESSKEY 和 VOLC_SECRETKEY。
+请预先获取环境变量 VOLCENGINE_ACCESS_KEY 和 VOLCENGINE_SECRET_KEY。
 
 ```json
 {
@@ -614,8 +614,8 @@ OAuth 2.0
         "mcp-server-vefaas-function"
       ],
       "env": {
-        "VOLC_ACCESSKEY": "xxx",
-        "VOLC_SECRETKEY": "xxx"
+        "VOLCENGINE_ACCESS_KEY": "xxx",
+        "VOLCENGINE_SECRET_KEY": "xxx"
       }
     }
   }

--- a/server/mcp_server_vefaas_function/mcp.json
+++ b/server/mcp_server_vefaas_function/mcp.json
@@ -8,8 +8,8 @@
         "mcp-server-vefaas-function"
       ],
       "env": {
-        "VOLC_ACCESSKEY": "xxx",
-        "VOLC_SECRETKEY": "xxx"
+        "VOLCENGINE_ACCESS_KEY": "xxx",
+        "VOLCENGINE_SECRET_KEY": "xxx"
       }
     }
   }

--- a/server/mcp_server_vefaas_function/src/mcp_server_vefaas_function/sign.py
+++ b/server/mcp_server_vefaas_function/src/mcp_server_vefaas_function/sign.py
@@ -39,8 +39,8 @@ Host = "iam.volcengineapi.com"
 ContentType = "application/x-www-form-urlencoded"
 
 # 请求的凭证，从IAM或者STS服务中获取
-AK = os.getenv("VOLC_ACCESSKEY")
-SK = os.getenv("VOLC_SECRETKEY")
+AK = os.getenv("VOLCENGINE_ACCESS_KEY")
+SK = os.getenv("VOLCENGINE_SECRET_KEY")
 # 当使用临时凭证时，需要使用到SessionToken传入Header，并计算进SignedHeader中，请自行在header参数中添加X-Security-Token头
 # SessionToken = ""
 
@@ -187,10 +187,10 @@ def get_authorization_credentials(ctx: Context = None) -> tuple[str, str, str]:
         ValueError: If authorization information is missing or invalid
     """
     # First try environment variables
-    if "VOLC_ACCESSKEY" in os.environ and "VOLC_SECRETKEY" in os.environ:
+    if "VOLCENGINE_ACCESS_KEY" in os.environ and "VOLCENGINE_SECRET_KEY" in os.environ:
         return (
-            os.environ["VOLC_ACCESSKEY"],
-            os.environ["VOLC_SECRETKEY"],
+            os.environ["VOLCENGINE_ACCESS_KEY"],
+            os.environ["VOLCENGINE_SECRET_KEY"],
             ""  # No session token for static credentials
         )
 

--- a/server/mcp_server_vefaas_function/src/mcp_server_vefaas_function/vefaas_server_test.py
+++ b/server/mcp_server_vefaas_function/src/mcp_server_vefaas_function/vefaas_server_test.py
@@ -6,11 +6,11 @@ from vefaas_server import does_function_exist
 class TestVeFaaSServerIntegration(unittest.TestCase):
     def setUp(self):
         # Check if credentials are available
-        self.ak = os.environ.get("VOLC_ACCESSKEY")
-        self.sk = os.environ.get("VOLC_SECRETKEY")
+        self.ak = os.environ.get("VOLCENGINE_ACCESS_KEY")
+        self.sk = os.environ.get("VOLCENGINE_SECRET_KEY")
         if not self.ak or not self.sk:
             self.assertFalse(
-                "VOLC_ACCESSKEY or VOLC_SECRETKEY environment variables not set"
+                "VOLCENGINE_ACCESS_KEY or VOLCENGINE_SECRET_KEY environment variables not set"
             )
 
     def test_does_function_exist_with_real_credentials(self):


### PR DESCRIPTION
The environment variables VOLC_ACCESSKEY and VOLC_SECRETKEY have been renamed to VOLCENGINE_ACCESS_KEY and VOLCENGINE_SECRET_KEY respectively. This change ensures consistency with the naming conventions used across the platform and improves readability. The update affects the README, configuration files, and source code where these variables are referenced.