### PR TITLE
fix(imports): Update import statements to use relative imports

### DIFF
--- a/server/mcp_server_vefaas_function/src/mcp_server_vefaas_function/stdio.py
+++ b/server/mcp_server_vefaas_function/src/mcp_server_vefaas_function/stdio.py
@@ -1,4 +1,4 @@
-from vefaas_server import mcp
+from .vefaas_server import mcp
 import logging
 
 logging.basicConfig(

--- a/server/mcp_server_vefaas_function/src/mcp_server_vefaas_function/vefaas_server.py
+++ b/server/mcp_server_vefaas_function/src/mcp_server_vefaas_function/vefaas_server.py
@@ -11,7 +11,7 @@ import base64
 import logging
 import tempfile
 import zipfile
-from sign import request, get_authorization_credentials
+from .sign import request, get_authorization_credentials
 import json
 from mcp.server.session import ServerSession
 from mcp.server.fastmcp import Context, FastMCP


### PR DESCRIPTION
The import statements in `stdio.py` and `vefaas_server.py` were updated to use relative imports instead of absolute imports. This change ensures that the modules are correctly referenced when the package is used as a submodule or in a different context, improving the robustness and portability of the code.