### PR TITLE
fix(sign): Include token in request headers

### DIFF
--- a/server/mcp_server_vefaas_function/src/mcp_server_vefaas_function/sign.py
+++ b/server/mcp_server_vefaas_function/src/mcp_server_vefaas_function/sign.py
@@ -163,7 +163,7 @@ def request(method, date, query, header, ak, sk, token, action, body):
         signature,
     )
     header = {**header, **sign_result}
-    # header = {**header, **{"X-Security-Token": SessionToken}}
+    header = {**header, **{"X-Security-Token": token}}
     # 第六步：将 Signature 签名写入 HTTP Header 中，并发送 HTTP 请求。
     r = requests.request(method=method,
                          url="https://{}{}".format(request_param["host"], request_param["path"]),


### PR DESCRIPTION
The token was previously commented out and not included in the request headers. This fix ensures the token is added to the headers, which is necessary for authenticating requests and maintaining secure communication with the server.