### PR TITLE
[fix]the code cannot be executed properly due to the lack of an auth …

### DIFF
--- a/server/mcp_server_vefaas_sandbox/README.md
+++ b/server/mcp_server_vefaas_sandbox/README.md
@@ -54,7 +54,10 @@ OAuth 2.0
 
 ### 获取 veFaaS Code-Sandbox 服务的访问入口
 
-参考火山引擎 veFaaS [一键部署 Code Sandbox Agent 应用](https://www.volcengine.com/docs/6662/1538139)，获取 veFaaS Code Sandbox Agent 服务的访问入口，如 `xxxxxxxxxxx.apigateway-cn-beijing.volceapi.com`，获取 `xxxxxxxxxxx.apigateway-cn-beijing.volceapi.com`，用于下方的 `SANDBOX_API` 配置。
+参考火山引擎 veFaaS [一键部署 Code Sandbox Agent 应用](https://www.volcengine.com/docs/6662/1538139)，完成一下配置：
+1. 获取 veFaaS Code Sandbox Agent 服务的访问入口，如 `xxxxxxxxxxx.apigateway-cn-beijing.volceapi.com`，获取 `xxxxxxxxxxx.apigateway-cn-beijing.volceapi.com`，用于下方的 `SANDBOX_API` 配置。
+2. 获取auth token用于下方的`AUTH_TOKEN`配置。
+
 
 ### uvx
 
@@ -69,7 +72,8 @@ OAuth 2.0
         "mcp-server-vefaas-sandbox"
       ],
       "env": {
-        "SANDBOX_API": "your-sandbox-apig-address"
+        "SANDBOX_API": "your-sandbox-apig-address",
+        "AUTH_TOKEN": "your-sandbox-apig-auth-token"
       }
     }
   }

--- a/server/mcp_server_vefaas_sandbox/README.md
+++ b/server/mcp_server_vefaas_sandbox/README.md
@@ -54,7 +54,7 @@ OAuth 2.0
 
 ### 获取 veFaaS Code-Sandbox 服务的访问入口
 
-参考火山引擎 veFaaS [一键部署 Code Sandbox Agent 应用](https://www.volcengine.com/docs/6662/1538139)，完成一下配置：
+参考火山引擎 veFaaS [一键部署 Code Sandbox Agent 应用](https://www.volcengine.com/docs/6662/1538139)，完成以下配置：
 1. 获取 veFaaS Code Sandbox Agent 服务的访问入口，如 `xxxxxxxxxxx.apigateway-cn-beijing.volceapi.com`，获取 `xxxxxxxxxxx.apigateway-cn-beijing.volceapi.com`，用于下方的 `SANDBOX_API` 配置。
 2. 获取auth token用于下方的`AUTH_TOKEN`配置。
 

--- a/server/mcp_server_vefaas_sandbox/src/mcp_server_vefaas_sandbox/server.py
+++ b/server/mcp_server_vefaas_sandbox/src/mcp_server_vefaas_sandbox/server.py
@@ -13,7 +13,7 @@ Sandbox_API_BASE = (
     "xxx.apigateway-cn-beijing.volceapi.com"  # 替换为用户沙盒服务 APIG 地址
 )
 
-# send http reqeust to SandboxFusion run_code api
+# send http request to SandboxFusion run_code api
 def send_request(payload):
     auth_token = os.getenv("AUTH_TOKEN")
 

--- a/server/mcp_server_vefaas_sandbox/src/mcp_server_vefaas_sandbox/server.py
+++ b/server/mcp_server_vefaas_sandbox/src/mcp_server_vefaas_sandbox/server.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 import argparse
 import json
 import os
@@ -14,10 +15,17 @@ Sandbox_API_BASE = (
 
 # send http reqeust to SandboxFusion run_code api
 def send_request(payload):
+    auth_token = os.getenv("AUTH_TOKEN")
+
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json, text/plain, */*",
     }
+
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+    else:
+        logger.warning("AUTH_TOKEN environment variable not set. Request will be sent without Authorization header.")
     sandbox_api = os.getenv("SANDBOX_API", Sandbox_API_BASE)
     conn = http.client.HTTPSConnection(sandbox_api)
 


### PR DESCRIPTION
# What does this PR do?
When I deployed MCP sandbox service based https://github.com/volcengine/mcp-server/tree/main/server/mcp_server_vefaas_sandbox, I could get the function's metadata, but encountered errors when making calls.
I found that the Sandbox API requires not only a url but also an authorization token.