### PR TITLE
Fix security issue of dependency of VEEN and TrafficRoute

### DIFF
--- a/server/mcp_server_traffic_route/nodejs/package.json
+++ b/server/mcp_server_traffic_route/nodejs/package.json
@@ -34,7 +34,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@modelcontextprotocol/inspector": "^0.8.2",
+    "@modelcontextprotocol/inspector": ">=0.16.2",
     "@types/node": "^22.14.1",
     "typescript": "^5.8.3"
   },

--- a/server/mcp_server_veen/nodejs/package.json
+++ b/server/mcp_server_veen/nodejs/package.json
@@ -34,7 +34,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@modelcontextprotocol/inspector": "^0.8.2",
+    "@modelcontextprotocol/inspector": ">=0.16.2",
     "@types/node": "^22.14.1",
     "typescript": "^5.8.3"
   },


### PR DESCRIPTION
Update the dependency to avoid the security issue caused by updating npm package `@modelcontextprotocol/inspector`.

- VEEN
- TrafficRoute