### PR TITLE
vedbm: 统一工具函数返回值为字典格式

### DIFF
--- a/server/mcp_server_vedb_mysql/src/mcp_server_vedb_mysql/tools_db_accts.py
+++ b/server/mcp_server_vedb_mysql/src/mcp_server_vedb_mysql/tools_db_accts.py
@@ -77,7 +77,7 @@ def list_vedb_mysql_instance_accounts(
 )
 def modify_db_account_description(instance_id: str,
                                   account_name: str,
-                                  account_desc: str) -> str:
+                                  account_desc: str) -> dict[str, Any]:
     req = {
         "instance_id": instance_id,
         "account_name": account_name,
@@ -85,7 +85,7 @@ def modify_db_account_description(instance_id: str,
     }
     req = {k: v for k, v in req.items() if v is not None}
     vedbm_resource_sdk.modify_db_account_description(req)
-    return "succ"
+    return {"succ": "true"}
 
 
 @mcp_server.tool(
@@ -93,7 +93,7 @@ def modify_db_account_description(instance_id: str,
 )
 def modify_database_description(instance_id: str,
                                 db_name: str,
-                                db_desc: str) -> str:
+                                db_desc: str) -> dict[str, Any]:
     req = {
         "instance_id": instance_id,
         "db_name": db_name,
@@ -101,7 +101,7 @@ def modify_database_description(instance_id: str,
     }
     req = {k: v for k, v in req.items() if v is not None}
     vedbm_resource_sdk.modify_database_description(req)
-    return "succ"
+    return {"succ": "true"}
 
 @mcp_server.tool(
     description="在实例内创建mysql账号。触发示例：在实例vedbm-instanceid内创建普通新账号test_mcp，密码为Password123"
@@ -111,7 +111,7 @@ def create_db_account(instance_id: str,
                       account_password: str,
                       account_type: Annotated[str, Field(examples=['Normal','Super'])],
                       account_desc: str = None,
-                      account_privileges: list[dict[str, Any]] = None) -> str:
+                      account_privileges: list[dict[str, Any]] = None) -> dict[str, Any]:
     req = {
         "instance_id": instance_id,
         "account_name": account_name,
@@ -122,7 +122,7 @@ def create_db_account(instance_id: str,
     }
     req = {k: v for k, v in req.items() if v is not None}
     vedbm_resource_sdk.create_db_account(req)
-    return "succ"
+    return {"succ": "true"}
 
 @mcp_server.tool(
     description="在实例内创建mysql数据库。触发示例：vedbm-instanceid下创建数据库test_db"
@@ -131,7 +131,7 @@ def create_database(instance_id: str,
                     db_name: str,
                     character_set_name: Optional[str] = 'utf8mb4',
                     databases_privileges: Optional[list[dict[str, Any]]] = None,
-                    db_desc: Optional[str] = None) -> str:
+                    db_desc: Optional[str] = None) -> dict[str, Any]:
     req = {
         "instance_id": instance_id,
         "db_name": db_name,
@@ -141,4 +141,4 @@ def create_database(instance_id: str,
     }
     req = {k: v for k, v in req.items() if v is not None}
     vedbm_resource_sdk.create_database(req)
-    return "succ"
+    return {"succ": "true"}

--- a/server/mcp_server_vedb_mysql/src/mcp_server_vedb_mysql/tools_instances.py
+++ b/server/mcp_server_vedb_mysql/src/mcp_server_vedb_mysql/tools_instances.py
@@ -130,21 +130,21 @@ def create_vedb_mysql_instance(
     description="为实例绑定标签，支持批量操作"
 )
 def add_tags_to_resource(instance_ids: list[str],
-                         tags: list[dict[str, Any]]) -> str:
+                         tags: list[dict[str, Any]]) -> dict[str, Any]:
     req = {
         "instance_ids": instance_ids,
         "tags": tags,
     }
     req = {k: v for k, v in req.items() if v is not None}
     vedbm_resource_sdk.add_tags_to_resource(req)
-    return "success"
+    return {"succ": "true"}
 
 @mcp_server.tool(
     description="为实例解绑标签，支持批量操作"
 )
 def remove_tags_from_resource(instance_ids: list[str],
                               all: Optional[Annotated[bool,Field(description='是否解绑指定实例上的所有标签')]] = None,
-                              tag_keys: list[str] = None) -> str:
+                              tag_keys: list[str] = None) -> dict[str, Any]:
     req = {
         "instance_ids": instance_ids,
         "all": all,
@@ -152,17 +152,17 @@ def remove_tags_from_resource(instance_ids: list[str],
     }
     req = {k: v for k, v in req.items() if v is not None}
     vedbm_resource_sdk.remove_tags_from_resource(req)
-    return "success"
+    return {"succ": "true"}
 
 @mcp_server.tool(
     description="切换实例主节点到指定节点"
 )
 def change_master(instance_id: str,
-                  target_node: Annotated[str, Field(examples=['vedbm-****-1'])]) -> str:
+                  target_node: Annotated[str, Field(examples=['vedbm-****-1'])]) -> dict[str, Any]:
     req = {
         "cluster_name": instance_id,
         "target_node": target_node,
     }
     req = {k: v for k, v in req.items() if v is not None}
     vedbm_resource_sdk.change_master(req)
-    return "success"
+    return {"succ": "true"}

--- a/server/mcp_server_vedb_mysql/src/mcp_server_vedb_mysql/tools_net.py
+++ b/server/mcp_server_vedb_mysql/src/mcp_server_vedb_mysql/tools_net.py
@@ -34,7 +34,7 @@ def bind_allowlist_to_vedb_mysql_instances(
         instance_ids=list(instances_id),
     )
     openapi_cli.associate_allow_list(req)
-    return {"status": "bind success"}
+    return {"bind": "success"}
 
 @mcp_server.tool(
     description="查询实例绑定的白名单信息。触发示例：查询实例vedbm-****当前绑定的所有白名单信息"


### PR DESCRIPTION
避免产生这种错误：

```
File "/home/faas/.cache/uv/archive-v0/ntlbnfich6i5001wJ9h1R/lib/python3.12/site-packages/mcp_server_vedb_mysql/tools_net.py", line 11, in <module>

@mcp_server.tool(

^^^^^^^^^^^^^^^^

File "/home/faas/.cache/uv/archive-v0/ntlbnfich6i5001wJ9h1R/lib/python3.12/site-packages/mcp/server/fastmcp/server.py", line 478, in decorator

self.add_tool(

File "/home/faas/.cache/uv/archive-v0/ntlbnfich6i5001wJ9h1R/lib/python3.12/site-packages/mcp/server/fastmcp/server.py", line 408, in add_tool

self._tool_manager.add_tool(

File "/home/faas/.cache/uv/archive-v0/ntlbnfich6i5001wJ9h1R/lib/python3.12/site-packages/mcp/server/fastmcp/tools/tool_manager.py", line 57, in add_tool

tool = Tool.from_function(

^^^^^^^^^^^^^^^^^^^

File "/home/faas/.cache/uv/archive-v0/ntlbnfich6i5001wJ9h1R/lib/python3.12/site-packages/mcp/server/fastmcp/tools/base.py", line 68, in from_function

func_arg_metadata = func_metadata(

^^^^^^^^^^^^^^

File "/home/faas/.cache/uv/archive-v0/ntlbnfich6i5001wJ9h1R/lib/python3.12/site-packages/mcp/server/fastmcp/utilities/func_metadata.py", line 313, in func_metadata

output_model, output_schema, wrap_output = _try_create_model_and_schema(

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/home/faas/.cache/uv/archive-v0/ntlbnfich6i5001wJ9h1R/lib/python3.12/site-packages/mcp/server/fastmcp/utilities/func_metadata.py", line 391, in _try_create_model_and_schema

model = _create_wrapped_model(func_name, original_annotation)

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/home/faas/.cache/uv/archive-v0/ntlbnfich6i5001wJ9h1R/lib/python3.12/site-packages/mcp/server/fastmcp/utilities/func_metadata.py", line 483, in _create_wrapped_model

return create_model(model_name, result=annotation)

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/opt/bytefaas/site-packages/pydantic/main.py", line 1678, in create_model

return meta(

^^^^^

File "/opt/bytefaas/site-packages/pydantic/_internal/_model_construction.py", line 113, in __new__

private_attributes = inspect_namespace(

^^^^^^^^^^^^^^^^^^

File "/opt/bytefaas/site-packages/pydantic/_internal/_model_construction.py", line 506, in inspect_namespace

raise PydanticUserError(

pydantic.errors.PydanticUserError: A non-annotated attribute was detected: `result = <class 'str'>`. All model fields require a type annotation; if `result` is not meant to be a field, you may be able to resolve this error by annotating it as a `ClassVar` or updating `model_config['ignored_types']`.
```