### PR TITLE
fix: fix error of pyproject.toml dependencies

### DIFF
--- a/server/mcp_server_rds_mssql/src/pyproject.toml
+++ b/server/mcp_server_rds_mssql/src/pyproject.toml
@@ -5,9 +5,9 @@ description = "MCP server for rds_mssql"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp[cli],"
-    "mcp>=1.12.0,"
-    "volcengine-python-sdk>=4.0.34,"
+    "mcp[cli]",
+    "mcp>=1.12.0",
+    "volcengine-python-sdk>=4.0.34",
 ]
 
 [project.scripts]


### PR DESCRIPTION
There are syntax errors in  pyproject.toml of mcp_server_rds_mssql. 
Old:
    "mcp[cli],"
    "mcp>=1.12.0,"
    "volcengine-python-sdk>=4.0.34,"

New:
    "mcp[cli]",
    "mcp>=1.12.0",
    "volcengine-python-sdk>=4.0.34",