### PR TITLE
docs: add mcp-divoom-lan to third-party MCP list

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ MCP Server列表 与 **[火山引擎大模型生态广场](https://www.volcengin
 
 ### **其他**  
 
+- **[mcp-divoom-lan](https://github.com/DivoomDevelop/mcp-divoom-lan)**：基于 MCP 的 Divoom 局域网表盘定制（读写本地表盘配置、替换底图、亮度与切盘、multipart 上传等）；stdio，需在局域网访问实体设备并配置环境变量 DIVOOM_DEVICE_HOST（及可选端口/超时）。MIT；推荐通过 npx -y mcp-divoom-lan（npm 0.1.2 及以上）或 node dist/index.js 启动。  
 - **[Time](https://github.com/modelcontextprotocol/servers/tree/main/src/time)**：Time and timezone conversion capabilities.  
 - **[Spotify](https://github.com/varunneal/spotify-mcp)**：This MCP allows an LLM to play and use Spotify.  
 - **[cognee-mcp](https://github.com/topoteretes/cognee/tree/main/cognee-mcp)**：GraphRAG memory server with customizable ingestion, data processing and search.  


### PR DESCRIPTION
## Summary

Add **[mcp-divoom-lan](https://github.com/DivoomDevelop/mcp-divoom-lan)** to the third-party MCP list under **「其他」**: Divoom watchface customization over **LAN** (read/patch dial config, replace background, brightness, dial switch, multipart uploads).

## Open source

- **License:** MIT
- **Repository:** https://github.com/DivoomDevelop/mcp-divoom-lan

## Runtime & install

- **Transport:** stdio (Node.js 20+)
- **User environment:** end users must reach the physical device on the **same LAN**; set `DIVOOM_DEVICE_HOST` (optional `DIVOOM_DEVICE_PORT`, `DIVOOM_TIMEOUT_MS`).
- **Install:** `npx -y mcp-divoom-lan` (npm 0.1.2+ with `bin` entry) or `node dist/index.js` after clone/build.

## Notes for reviewers

- No Volcengine cloud resources required; purely **local/LAN** device HTTP API access.
- Listing request aligns with MCP ecosystem plaza third-party entries (similar to existing external links in README).
