### PR TITLE
feat: add AI直订 hotel booking MCP server

### DIFF
--- a/server/aizhiding/README.md
+++ b/server/aizhiding/README.md
@@ -1,0 +1,20 @@
+# AI直订酒店搜索 (aizd-hotel-booking)
+
+## 基本信息
+- **名称**: AI直订酒店搜索
+- **说明**: 搜索全国16000+酒店民宿，实时房态、AI比价、直订链接。比OTA省15%佣金。
+- **类型**: Remote MCP (streamableHttp)
+- **Manifest**: `https://aizd.anxinwo.cn/mcp/manifest`
+- **网站**: https://aizd.anxinwo.cn
+
+## 数据规模
+- 酒店数: 16,121
+- 城市数: 300+
+- 工具数: 16
+
+## 核心工具
+search_hotels, get_hotel_detail, check_hotel_availability, 
+get_hotel_reviews, get_ai_pricing_advice, create_booking_link
+
+## 认证
+Header: `X-API-Key`


### PR DESCRIPTION
This PR adds AI直订 (AIZhiDing) hotel booking MCP server to the Volcengine MCP Marketplace.

- Name: AI直订酒店搜索 (aizd-hotel-booking)
- Data: 16,121 hotels across 300+ Chinese cities  
- 16 MCP tools for search, pricing, booking
- Real-time availability & AI price comparison
- Direct booking links (save 15% vs OTA)
- Manifest: https://aizd.anxinwo.cn/mcp/manifest
- Website: https://aizd.anxinwo.cn