### PR TITLE
fix(traffic-route): fix build failure and import path in Python MCP server

### DIFF
--- a/server/mcp_server_traffic_route/python/pyproject.toml
+++ b/server/mcp_server_traffic_route/python/pyproject.toml
@@ -2,7 +2,6 @@
 name = "mcp-server-traffic-route"
 version = "0.1.0"
 description = "Apply, configure, and query for edge computing nodes, including virtual machines, images, bare metal, and corresponding network configurations."
-readme = "../README.md"
 requires-python = ">=3.11"
 dependencies = [
     "mcp>=1.12.0",

--- a/server/mcp_server_traffic_route/python/vcloud/traffic_route/server.py
+++ b/server/mcp_server_traffic_route/python/vcloud/traffic_route/server.py
@@ -1,11 +1,9 @@
 # coding:utf-8
-
-from vcloud.veenedge.mcp_server import create_mcp_server
+from vcloud.traffic_route.mcp_server import create_mcp_server
 from dotenv import load_dotenv
-import asyncio
 
 load_dotenv()
 
 mcp = create_mcp_server()
 if __name__ == "__main__":
-    asyncio.run(mcp.run())
+    mcp.run()


### PR DESCRIPTION
## Description

Fix two issues in the TrafficRoute Python MCP server that prevent it from building and running correctly.

## Changes

### 1. pyproject.toml - Fix build failure with uvx

The `readme = "../README.md"` references a file in the parent directory. When building via `uvx --from git+...`, setuptools's security check blocks access to files outside the package directory, causing `DistutilsOptionError`.

**Fix**: Remove the `readme` field. The package can still be documented via other means.

### 2. server.py - Fix import path and run method

- Wrong import path: `from vcloud.veenedge.mcp_server import create_mcp_server` — the module `vcloud.veenedge` does not exist. The correct import is `from vcloud.traffic_route.mcp_server import create_mcp_server`.
- `asyncio.run(mcp.run())` fails with `TypeError: An asyncio.Future, a coroutine or an awaitable is required` on newer MCP SDK versions. Changed to `mcp.run()` which works correctly.

## Testing

Tested locally with `uvx --from <local_path> mcp-server-traffic-route` — the server starts successfully and accepts MCP stdio protocol connections.