### PR TITLE
ci: publish Python packages on version changes

### DIFF
--- a/.github/scripts/changed_python_packages.py
+++ b/.github/scripts/changed_python_packages.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""List server packages whose project version changed between two revisions."""
+
+import json
+import subprocess
+import sys
+import tomllib
+from pathlib import PurePosixPath
+
+
+EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+PATHSPEC = ":(glob)server/**/pyproject.toml"
+
+
+def git(*args: str) -> bytes:
+    return subprocess.check_output(("git", *args), stderr=subprocess.DEVNULL)
+
+
+def project_at(revision: str, path: str) -> dict[str, str] | None:
+    try:
+        content = git("show", f"{revision}:{path}")
+    except subprocess.CalledProcessError:
+        return None
+
+    project = tomllib.loads(content.decode()).get("project", {})
+    if not isinstance(project.get("name"), str) or not isinstance(
+        project.get("version"), str
+    ):
+        raise ValueError(f"{path} must define string project.name and project.version")
+    return project
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit(f"usage: {sys.argv[0]} BASE_SHA HEAD_SHA")
+
+    base, head = sys.argv[1:]
+    if base == "0" * 40:
+        base = EMPTY_TREE
+
+    changed_paths = git(
+        "diff", "--name-only", "--diff-filter=AM", base, head, "--", PATHSPEC
+    ).decode().splitlines()
+
+    packages = []
+    for path in changed_paths:
+        previous = project_at(base, path)
+        current = project_at(head, path)
+        if current is None:
+            continue
+        if previous is None or previous["version"] != current["version"]:
+            packages.append(
+                {
+                    "directory": str(PurePosixPath(path).parent),
+                    "name": current["name"],
+                    "version": current["version"],
+                }
+            )
+
+    print(json.dumps(packages, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/publish-python-packages.yml
+++ b/.github/workflows/publish-python-packages.yml
@@ -1,6 +1,11 @@
 name: Publish Python packages
 
 on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "server/**/pyproject.toml"
   push:
     branches:
       - main
@@ -33,13 +38,13 @@ jobs:
       - name: Detect package version changes
         id: detect
         env:
-          BASE_SHA: ${{ github.event.before }}
-          HEAD_SHA: ${{ github.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           packages="$(python .github/scripts/changed_python_packages.py "$BASE_SHA" "$HEAD_SHA")"
           echo "packages=$packages" >> "$GITHUB_OUTPUT"
 
-  publish:
+  build-and-publish:
     needs: detect-version-changes
     if: needs.detect-version-changes.outputs.packages != '[]'
     runs-on: ubuntu-latest
@@ -67,7 +72,12 @@ jobs:
       - name: Check distribution
         run: python -m twine check "$RUNNER_TEMP"/dist/*
 
+      - name: Confirm pull request dry run
+        if: github.event_name == 'pull_request'
+        run: echo "Build checks passed; upload is skipped for pull requests."
+
       - name: Publish to PyPI
+        if: github.event_name == 'push'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-python-packages.yml
+++ b/.github/workflows/publish-python-packages.yml
@@ -77,9 +77,8 @@ jobs:
         run: python -m pip install --upgrade build twine
 
       - name: Build ${{ matrix.package.name }} ${{ matrix.package.version }}
-        env:
-          PACKAGE_DIRECTORY: ${{ matrix.package.directory }}
-        run: python -m build --outdir "$RUNNER_TEMP/dist" "$PACKAGE_DIRECTORY"
+        working-directory: ${{ matrix.package.directory }}
+        run: python -m build --outdir "$RUNNER_TEMP/dist" .
 
       - name: Check distribution
         run: python -m twine check "$RUNNER_TEMP"/dist/*

--- a/.github/workflows/publish-python-packages.yml
+++ b/.github/workflows/publish-python-packages.yml
@@ -61,6 +61,18 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Show package information
+        env:
+          PACKAGE_NAME: ${{ matrix.package.name }}
+          PACKAGE_VERSION: ${{ matrix.package.version }}
+          PACKAGE_DIRECTORY: ${{ matrix.package.directory }}
+          RUN_MODE: ${{ github.event_name == 'pull_request' && 'pull request check' || 'main branch publish' }}
+        run: |
+          echo "Package: $PACKAGE_NAME"
+          echo "Version: $PACKAGE_VERSION"
+          echo "Directory: $PACKAGE_DIRECTORY"
+          echo "Mode: $RUN_MODE"
+
       - name: Install build tools
         run: python -m pip install --upgrade build twine
 

--- a/.github/workflows/publish-python-packages.yml
+++ b/.github/workflows/publish-python-packages.yml
@@ -1,0 +1,74 @@
+name: Publish Python packages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "server/**/pyproject.toml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-python-packages
+  cancel-in-progress: false
+
+jobs:
+  detect-version-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.detect.outputs.packages }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Detect package version changes
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          packages="$(python .github/scripts/changed_python_packages.py "$BASE_SHA" "$HEAD_SHA")"
+          echo "packages=$packages" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: detect-version-changes
+    if: needs.detect-version-changes.outputs.packages != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.detect-version-changes.outputs.packages) }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Build ${{ matrix.package.name }} ${{ matrix.package.version }}
+        env:
+          PACKAGE_DIRECTORY: ${{ matrix.package.directory }}
+        run: python -m build --outdir "$RUNNER_TEMP/dist" "$PACKAGE_DIRECTORY"
+
+      - name: Check distribution
+        run: python -m twine check "$RUNNER_TEMP"/dist/*
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload --non-interactive "$RUNNER_TEMP"/dist/*


### PR DESCRIPTION
## Summary

- detect version changes in `server/**/pyproject.toml`
- build and validate only the affected package directory on pull requests
- publish affected packages only after changes reach `main`
- log the selected package name, version, directory, and run mode

## Configuration

The repository must define an Actions secret named `PYPI_API_TOKEN`.

## Verification

- direct and nested package paths were detected successfully
- wheel and source distribution builds passed `twine check`
- pull request dry run passed with the PyPI upload step skipped
- isolated package-directory build passed in the fork test run