### PR TITLE
chore(ecs): bump version to 0.2.0

### DIFF
--- a/server/mcp_server_ecs/pyproject.toml
+++ b/server/mcp_server_ecs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-ecs"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP Server for ECS"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Bump `mcp-server-ecs` from `0.1.0` to `0.2.0`.

After this pull request is merged, the package release workflow will build and publish only `server/mcp_server_ecs`.

## Verification

The version-change detector selects exactly:

- package: `mcp-server-ecs`
- version: `0.2.0`
- directory: `server/mcp_server_ecs`